### PR TITLE
Ensure buffer is big enough to do the 1st read.

### DIFF
--- a/Utilities/ByteUtils/ByteReader.cs
+++ b/Utilities/ByteUtils/ByteReader.cs
@@ -62,12 +62,15 @@ namespace Utilities
         public static string ReadNullTerminatedAnsiString(byte[] buffer, int offset)
         {
             StringBuilder builder = new StringBuilder();
-            char c = (char)ByteReader.ReadByte(buffer, offset);
-            while (c != '\0')
+            if (buffer.Length > offset)
             {
-                builder.Append(c);
-                offset++;
-                c = (char)ByteReader.ReadByte(buffer, offset);
+                char c = (char)ByteReader.ReadByte(buffer, offset);
+                while (c != '\0')
+                {
+                    builder.Append(c);
+                    offset++;
+                    c = (char)ByteReader.ReadByte(buffer, offset);
+                }
             }
             return builder.ToString();
         }
@@ -75,27 +78,38 @@ namespace Utilities
         public static string ReadNullTerminatedUTF16String(byte[] buffer, int offset)
         {
             StringBuilder builder = new StringBuilder();
-            char c = (char)LittleEndianConverter.ToUInt16(buffer, offset);
-            while (c != 0)
+            if (buffer.Length > offset)
             {
-                builder.Append(c);
-                offset += 2;
-                c = (char)LittleEndianConverter.ToUInt16(buffer, offset);
+                char c = (char)LittleEndianConverter.ToUInt16(buffer, offset);
+                while (c != 0)
+                {
+                    builder.Append(c);
+                    offset += 2;
+                    c = (char)LittleEndianConverter.ToUInt16(buffer, offset);
+                }
             }
             return builder.ToString();
         }
 
         public static string ReadNullTerminatedAnsiString(byte[] buffer, ref int offset)
         {
-            string result = ReadNullTerminatedAnsiString(buffer, offset);
-            offset += result.Length + 1;
+            string result = string.Empty;
+            if (buffer.Length > offset)
+            {
+                result = ReadNullTerminatedAnsiString(buffer, offset);
+                offset += result.Length + 1;
+            }
             return result;
         }
 
         public static string ReadNullTerminatedUTF16String(byte[] buffer, ref int offset)
         {
-            string result = ReadNullTerminatedUTF16String(buffer, offset);
-            offset += result.Length * 2 + 2;
+            string result = string.Empty;
+            if (buffer.Length > offset)
+            {
+                result = ReadNullTerminatedUTF16String(buffer, offset);
+                offset += result.Length * 2 + 2;
+            }
             return result;
         }
 


### PR DESCRIPTION
I was trying to connect to an old SMB1 HP machine. During the connect phase, in the NegotiateResponse constructor, the codebase was throwing an exception because the buffer didn't have enough bytes left to read the DomainName and the ServerName. My assumption is that these fields are optional and thus HP doesn't put them in the response or there is a firmware bug there.

I protected the low level functions to return empty string if the buffer doesn't have any more bytes (after the given offset).  Didn't bother to check if the buffer has enough space to complete the requested read since it would add unnecessary complexity to the low level functions, I didn't observe such an issue and if there is such an issue an exception will be thrown.