### PR TITLE
Prevent STATUS_PENDING being returned from SMB2Client.WaitForCommand 

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -438,7 +438,7 @@ namespace SMBLibrary.Client
 
         internal SMB2Command WaitForCommand(SMB2CommandName commandName)
         {
-            const int TimeOut = 5000;
+            const int TimeOut = 10000;
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
             while (stopwatch.ElapsedMilliseconds < TimeOut)
@@ -449,7 +449,7 @@ namespace SMBLibrary.Client
                     {
                         SMB2Command command = m_incomingQueue[index];
 
-                        if (command.CommandName == commandName)
+                        if (command.CommandName == commandName && command.Header.Status != NTStatus.STATUS_PENDING)
                         {
                             m_incomingQueue.RemoveAt(index);
                             return command;

--- a/SMBLibrary/SMBLibrary.csproj
+++ b/SMBLibrary/SMBLibrary.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>SMBLibrary</AssemblyName>
     <PackOnBuild>true</PackOnBuild>
     <PackageId>SMBLibraryLite</PackageId>
-    <PackageVersion>1.4.3-alpha</PackageVersion>
+    <PackageVersion>1.4.3-beta</PackageVersion>
     <Authors>jordanlytle,Jo0</Authors>
     <PackageLicenseUrl>https://github.com/jordanlytle/SMBLibrary/blob/master/License.txt</PackageLicenseUrl>
     <Owners>jordanlytle,Jo0</Owners>


### PR DESCRIPTION
Prevent STATUS_PENDING being returned from SMB2Client.WaitForCommand 