### PR TITLE
Add treeId to WaitForCommand

### DIFF
--- a/SMBLibrary/Client/SMB2Client.cs
+++ b/SMBLibrary/Client/SMB2Client.cs
@@ -325,7 +325,8 @@ namespace SMBLibrary.Client
 
             if (numberOfBytesReceived == 0)
             {
-                m_isConnected = false;
+                if(!m_clientSocket.Connected)
+                    m_isConnected = false;
             }
             else
             {
@@ -438,6 +439,11 @@ namespace SMBLibrary.Client
 
         internal SMB2Command WaitForCommand(SMB2CommandName commandName)
         {
+            return WaitForCommand(commandName, 0);
+        }
+
+        internal SMB2Command WaitForCommand(SMB2CommandName commandName, uint treeId)
+        {
             const int TimeOut = 10000;
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
@@ -449,7 +455,8 @@ namespace SMBLibrary.Client
                     {
                         SMB2Command command = m_incomingQueue[index];
 
-                        if (command.CommandName == commandName && command.Header.Status != NTStatus.STATUS_PENDING)
+                        if (command.CommandName == commandName && command.Header.Status != NTStatus.STATUS_PENDING
+                            && (treeId == 0 || treeId == command.Header.TreeID))
                         {
                             m_incomingQueue.RemoveAt(index);
                             return command;

--- a/SMBLibrary/Client/SMB2FileStore.cs
+++ b/SMBLibrary/Client/SMB2FileStore.cs
@@ -38,7 +38,7 @@ namespace SMBLibrary.Client
             request.ImpersonationLevel = ImpersonationLevel.Impersonation;
             TrySendCommand(request);
 
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.Create);
+            SMB2Command response = WaitForCommand(SMB2CommandName.Create);
             if (response != null)
             {
                 if (response.Header.Status == NTStatus.STATUS_SUCCESS && response is CreateResponse)
@@ -58,7 +58,7 @@ namespace SMBLibrary.Client
             CloseRequest request = new CloseRequest();
             request.FileId = (FileID)handle;
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.Close);
+            SMB2Command response = WaitForCommand(SMB2CommandName.Close);
             if (response != null)
             {
                 return response.Header.Status;
@@ -77,7 +77,7 @@ namespace SMBLibrary.Client
             request.ReadLength = (uint)maxCount;
 
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.Read);
+            SMB2Command response = WaitForCommand(SMB2CommandName.Read);
             if (response != null)
             {
                 if (response.Header.Status == NTStatus.STATUS_SUCCESS && response is ReadResponse)
@@ -100,7 +100,7 @@ namespace SMBLibrary.Client
             request.Data = data;
 
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.Write);
+            SMB2Command response = WaitForCommand(SMB2CommandName.Write);
             if (response != null)
             {
                 if (response.Header.Status == NTStatus.STATUS_SUCCESS && response is WriteResponse)
@@ -140,7 +140,7 @@ namespace SMBLibrary.Client
             request.FileName = fileName;
 
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.QueryDirectory);
+            SMB2Command response = WaitForCommand(SMB2CommandName.QueryDirectory);
             if (response != null)
             {
                 while (response.Header.Status == NTStatus.STATUS_SUCCESS && response is QueryDirectoryResponse)
@@ -149,7 +149,7 @@ namespace SMBLibrary.Client
                     result.AddRange(page);
                     request.Reopen = false;
                     TrySendCommand(request);
-                    response = m_client.WaitForCommand(SMB2CommandName.QueryDirectory);
+                    response = WaitForCommand(SMB2CommandName.QueryDirectory);
                 }
                 return response.Header.Status;
             }
@@ -167,7 +167,7 @@ namespace SMBLibrary.Client
             request.FileId = (FileID)handle;
 
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.QueryInfo);
+            SMB2Command response = WaitForCommand(SMB2CommandName.QueryInfo);
             if (response != null)
             {
                 if (response.Header.Status == NTStatus.STATUS_SUCCESS && response is QueryInfoResponse)
@@ -189,7 +189,7 @@ namespace SMBLibrary.Client
             request.SetFileInformation(information);
 
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.SetInfo);
+            SMB2Command response = WaitForCommand(SMB2CommandName.SetInfo);
             if (response != null)
             {
                 return response.Header.Status;
@@ -224,7 +224,7 @@ namespace SMBLibrary.Client
             request.FileId = (FileID)handle;
 
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.QueryInfo);
+            SMB2Command response = WaitForCommand(SMB2CommandName.QueryInfo);
             if (response != null)
             {
                 if (response.Header.Status == NTStatus.STATUS_SUCCESS && response is QueryInfoResponse)
@@ -252,7 +252,7 @@ namespace SMBLibrary.Client
             request.FileId = (FileID)handle;
 
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.QueryInfo);
+            SMB2Command response = WaitForCommand(SMB2CommandName.QueryInfo);
             if (response != null)
             {
                 if (response.Header.Status == NTStatus.STATUS_SUCCESS && response is QueryInfoResponse)
@@ -291,7 +291,7 @@ namespace SMBLibrary.Client
             request.Input = input;
             request.MaxOutputResponse = (uint)maxOutputLength;
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.IOCtl);
+            SMB2Command response = WaitForCommand(SMB2CommandName.IOCtl);
             if (response != null)
             {
                 if ((response.Header.Status == NTStatus.STATUS_SUCCESS || response.Header.Status == NTStatus.STATUS_BUFFER_OVERFLOW) && response is IOCtlResponse)
@@ -308,13 +308,18 @@ namespace SMBLibrary.Client
         {
             TreeDisconnectRequest request = new TreeDisconnectRequest();
             TrySendCommand(request);
-            SMB2Command response = m_client.WaitForCommand(SMB2CommandName.TreeDisconnect);
+            SMB2Command response = WaitForCommand(SMB2CommandName.TreeDisconnect);
             if (response != null)
             {
                 return response.Header.Status;
             }
 
             return NTStatus.STATUS_INVALID_SMB;
+        }
+
+        private SMB2Command WaitForCommand(SMB2CommandName commandName)
+        {
+            return m_client.WaitForCommand(commandName, m_treeID);
         }
 
         private void TrySendCommand(SMB2Command request)


### PR DESCRIPTION
Request from SMB2FileStore carries treeId. When multiple request comes from different from different SMB2FileStore, we need to use treeId to distinguish the response.